### PR TITLE
if ever we want to have a conda forge package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ example_charts/notebook_test.html
 example_charts/html_only_test.html
 example_charts/notebook_test.pdf
 example_charts/
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -26,11 +26,29 @@ Table of contents:
 
 ## Installation
 
+### Option 1: Using Conda (Recommended)
+
+If you use conda/mamba, this is the easiest installation method as it handles all dependencies automatically:
+
+```bash
+# Install from conda-forge (coming soon)
+conda install -c conda-forge py-allotax
+
+# Or build locally from source
+cd py-allotax
+conda build conda-recipe
+conda install --use-local py-allotax
+```
+
+The conda package automatically installs Node.js and runs `npm install` for you!
+
+### Option 2: Using pip
+
 From a local (your computer) coding environment:
 
 1. Requires `python3.11` or greater.
 
-1. If JavaScript tool installs are needed (never used or installed `npm`, `nvm`, `node`):
+1. If JavaScript tools are not installed (`npm`, `nvm`, `node`):
     1. [Install `nvm`](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating). `nvm` is a node version manager that streamlines installing the other 2.
     - Otherwise (not recommended): [steps to individually install `node` and `npm`](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm).
 1. Once you have `nvm`, install the latest of both `node` and `npm` with:
@@ -44,9 +62,20 @@ From a local (your computer) coding environment:
     pip3 install py-allotax
     ```
 
+1. Install Node.js dependencies (required):
+    ```bash
+    # Find where py-allotax was installed
+    python3 -c "import py_allotax; from pathlib import Path; print(Path(py_allotax.__file__).parent)"
+
+    # Navigate to that directory and run npm install
+    cd <path-from-above>
+    npm install
+    ```
+    This installs the required JavaScript dependencies including Puppeteer (which downloads a compatible Chrome browser).
+
 
 > Note:
-> We use `puppeteer.js` under the hood, which is going to download a compatible Chrome during installation.
+> With pip installation, you must manually run `npm install` in the package directory. If you skip this step, you'll get a clear error message with instructions when trying to use the package. **Using conda avoids this manual step entirely.**
 
 ## Usage instructions
 

--- a/conda-recipe/README.md
+++ b/conda-recipe/README.md
@@ -1,0 +1,50 @@
+# Conda Recipe for py-allotax
+
+This directory contains the conda recipe for building and distributing py-allotax via conda/conda-forge.
+
+## Why Conda?
+
+The conda package solves the Node.js dependency installation problem by:
+
+1. **Automatically installing Node.js** as a dependency
+2. **Running `npm install` automatically** via the `post-link.sh` script after installation
+3. **No manual steps required** for end users
+
+## Building the Package Locally
+
+```bash
+# From the repository root
+conda build conda-recipe
+
+# Install the locally built package
+conda install --use-local py-allotax
+```
+
+## Testing the Package
+
+```bash
+# Create a test environment
+conda create -n test-allotax python=3.11
+conda activate test-allotax
+
+# Install your locally built package
+conda install --use-local py-allotax
+
+# Test it
+python -c "from py_allotax.generate_svg import generate_svg; print('Success!')"
+```
+
+## Publishing to Conda-Forge
+
+To publish to conda-forge, follow the [conda-forge contribution guide](https://conda-forge.org/docs/maintainer/adding_pkgs.html):
+
+1. Fork the [staged-recipes repository](https://github.com/conda-forge/staged-recipes)
+2. Copy this recipe to `recipes/py-allotax/`
+3. Submit a pull request
+4. Address any feedback from conda-forge reviewers
+
+## Recipe Files
+
+- **meta.yaml**: Package metadata, dependencies, and build configuration
+- **build.sh**: Build script for Unix systems
+- **post-link.sh**: Post-installation script that runs `npm install` automatically

--- a/conda-recipe/build.sh
+++ b/conda-recipe/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Build script for conda package
+$PYTHON -m pip install . -vv --no-deps --no-build-isolation

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,0 +1,44 @@
+{% set name = "py-allotax" %}
+{% set version = "1.0.6" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  path: ..
+
+build:
+  number: 0
+
+requirements:
+  host:
+    - python >=3.11
+    - pip
+    - pdm-backend
+  run:
+    - python >=3.11
+    - pandas >=2.2.1
+    - numpy >=1.26
+    - nodejs >=18
+
+test:
+  imports:
+    - py_allotax
+  commands:
+    - python -c "import py_allotax; print('py-allotax installed successfully')"
+
+about:
+  home: https://github.com/compstorylab/py-allotax
+  license: MIT
+  license_file: LICENSE
+  summary: Python implementation of allotaxonometer to produce static graphs
+  description: |
+    py-allotax is a Python wrapper for the allotaxonometer-ui JavaScript library.
+    It allows users to generate allotaxonometry visualizations through Python,
+    outputting static PDFs, HTML files, or raw RTD data.
+  dev_url: https://github.com/compstorylab/py-allotax
+
+extra:
+  recipe-maintainers:
+    - compstorylab

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Post-link script to install Node.js dependencies after conda install
+# This runs automatically when the conda package is installed
+
+MESSAGES_FILE="${PREFIX}/.messages.txt"
+
+# Function to log to both stderr (for errors) and .messages.txt
+log_message() {
+    echo "$1" >> "$MESSAGES_FILE"
+}
+
+log_message ""
+log_message "==========================================  "
+log_message "Installing Node.js dependencies for py-allotax..."
+log_message "==========================================  "
+
+# Find the py_allotax package directory with proper glob expansion
+shopt -s nullglob
+PACKAGE_DIRS=("${PREFIX}"/lib/python*/site-packages/py_allotax)
+
+if [ ${#PACKAGE_DIRS[@]} -eq 0 ]; then
+    log_message "⚠ Warning: Could not find py_allotax package directory"
+    exit 0
+fi
+
+PACKAGE_DIR="${PACKAGE_DIRS[0]}"
+log_message "Package directory: $PACKAGE_DIR"
+
+# Navigate to the package directory and run npm install
+cd "$PACKAGE_DIR" || {
+    log_message "⚠ Error: Could not cd to $PACKAGE_DIR"
+    exit 1
+}
+
+if [ ! -f "package.json" ]; then
+    log_message "⚠ Warning: package.json not found"
+    exit 0
+fi
+
+log_message "Running npm install..."
+
+# Run npm install and capture output
+if npm install --production > /tmp/npm-install.log 2>&1; then
+    if [ -d "node_modules" ]; then
+        log_message "✓ Node.js dependencies installed successfully!"
+        log_message ""
+    else
+        log_message "⚠ Warning: npm install completed but node_modules not found"
+        log_message "  Manual install: cd $PACKAGE_DIR && npm install"
+        log_message ""
+    fi
+else
+    log_message "⚠ Error: npm install failed"
+    log_message "  See /tmp/npm-install.log for details"
+    log_message "  Manual install: cd $PACKAGE_DIR && npm install"
+    log_message ""
+fi
+
+exit 0


### PR DESCRIPTION
**Issue** In fresh environment, an old `puppeteer.js` version gets installed for some reason, throwing errors when importing the package. To fix it, people have to install puppeteer `^24.10.1` manually after having pip installed the package. My suspicion is that `npm install` never gets call when building the wheel, only in the docker compose file. 

Ashley's note that 
 - users needed to post install puppeteer==24.10.1 as opposed to ^24.10.1. This had it working.
- The conda install of nodejs did not fix the VACC problem. See the FAQ on this for the extra steps needed that had the user reconfiguring the chromium path. Not sure just installing nodejs would do anything.

**Potential Solution** To install `py-allotax` on the VACC, the easiest solution ended up using `conda` to install `nodejs`,  which then can be called from the correct environment. I think we should bite the bullet and do the same for new users; just have a conda forge package that install nodejs during installation, with a [post-link](https://docs.conda.io/projects/conda-build/en/latest/resources/link-scripts.html) that takes care of running `npm install`.